### PR TITLE
fix: make file & path handling work cross-platform

### DIFF
--- a/src-tauri/src/file_utils.rs
+++ b/src-tauri/src/file_utils.rs
@@ -3,7 +3,7 @@ use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs::{self, File};
-use std::io::{BufReader, Read, Write};
+use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use tauri::path::BaseDirectory;
 use tauri::{AppHandle, Manager};
@@ -14,6 +14,18 @@ use zip::write::FileOptions;
 use zip::{ZipArchive, ZipWriter};
 
 use crate::config::Config;
+
+/// Normalises any user-supplied "documents-relative" path so the Tauri path
+/// resolver and the OS file APIs both accept it.
+///
+/// The frontend used to hard-code Windows-style backslashes ("My
+/// Games\\FarmingSimulator2025"). On macOS / Linux the backslash is a regular
+/// filename character, so the resolver would build a literal directory called
+/// `My Games\FarmingSimulator2025` which obviously doesn't exist – producing
+/// the "could not be parsed/found/read" Sentry events. Always normalise.
+fn normalize_relative_path(input: &str) -> String {
+    input.replace('\\', "/")
+}
 
 /// Loads the config and returns it as a Config struct.
 #[tauri::command]
@@ -32,7 +44,7 @@ pub fn load_config(app_handle: tauri::AppHandle, game_data_directory: &str) -> J
         .path()
         .resolve("config.json", BaseDirectory::Config)
     {
-        Ok(bool) => bool,
+        Ok(p) => p,
         Err(e) => {
             sentry::capture_message(
                 &format!("Error creating config path: {}", e.to_string()),
@@ -44,22 +56,18 @@ pub fn load_config(app_handle: tauri::AppHandle, game_data_directory: &str) -> J
     };
     if !config_path.exists() {
         log::info!("config_path_does_not_exist {:?}", config_path);
-        // Write the default config to the file
-        match serde_json::to_string_pretty(&config) {
-            Ok(str) => str,
-            Err(e) => {
-                sentry::capture_message(
-                    &format!("Error serializing config: {}", e.to_string()),
-                    sentry::Level::Error,
-                );
-                log::error!("Error serializing config: {}", e);
-                return config.into();
+        // Make sure the parent directory exists before any future write attempt.
+        if let Some(parent) = config_path.parent() {
+            if !parent.exists() {
+                if let Err(e) = fs::create_dir_all(parent) {
+                    log::warn!("Error creating config dir {:?}: {}", parent, e);
+                }
             }
-        };
+        }
         return config.into();
     }
 
-    let file_content = match fs::read_to_string(config_path) {
+    let file_content = match fs::read_to_string(&config_path) {
         Ok(content) => content,
         Err(e) => {
             sentry::capture_message(
@@ -97,7 +105,7 @@ pub fn save_config(app_handle: tauri::AppHandle, config: &str) {
         .path()
         .resolve("config.json", BaseDirectory::Config)
     {
-        Ok(bool) => bool,
+        Ok(p) => p,
         Err(e) => {
             sentry::capture_message(
                 &format!("Error creating config path: {}", e.to_string()),
@@ -108,7 +116,20 @@ pub fn save_config(app_handle: tauri::AppHandle, config: &str) {
         }
     };
 
-    match fs::write(config_path, config) {
+    if let Some(parent) = config_path.parent() {
+        if !parent.exists() {
+            if let Err(e) = fs::create_dir_all(parent) {
+                sentry::capture_message(
+                    &format!("Error creating config dir {:?}: {}", parent, e),
+                    sentry::Level::Error,
+                );
+                log::error!("Error creating config dir {:?}: {}", parent, e);
+                return;
+            }
+        }
+    }
+
+    match fs::write(&config_path, config) {
         Ok(_) => (),
         Err(e) => {
             sentry::capture_message(
@@ -132,7 +153,11 @@ pub fn get_zip_file_paths(folder: &Path) -> Vec<PathBuf> {
                         Ok(entry) => {
                             let path = entry.path();
                             if path.is_file()
-                                && path.extension().and_then(|ext| ext.to_str()) == Some("zip")
+                                && path
+                                    .extension()
+                                    .and_then(|ext| ext.to_str())
+                                    .map(|ext| ext.eq_ignore_ascii_case("zip"))
+                                    .unwrap_or(false)
                             {
                                 zip_paths.push(path);
                             }
@@ -159,12 +184,42 @@ pub fn get_zip_file_paths(folder: &Path) -> Vec<PathBuf> {
     zip_paths
 }
 
+/// Converts an OS-specific relative path into the forward-slash form mandated
+/// by the ZIP spec (PKWARE APPNOTE 4.4.17.1). Without this, archives produced
+/// on Windows would carry `\` separators which most other tooling – including
+/// the same archive being read back on macOS / Linux – cannot resolve.
+fn zip_path_string(path: &Path) -> Option<String> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(part) => match part.to_str() {
+                Some(s) => parts.push(s.to_string()),
+                None => return None,
+            },
+            // Skip prefixes/roots/curdir/parentdir – we only want the relative pieces.
+            _ => {}
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("/"))
+    }
+}
+
 // Creates a zip archive of all files within path.
 pub fn create_zip_archive(
     path: PathBuf,
     output_path: PathBuf,
 ) -> Result<JsonValue, Box<dyn Error>> {
     log::info!("create_zip_archive {:?} {:?}", path, output_path);
+
+    if let Some(parent) = output_path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
     let file = std::fs::File::create(&output_path)?;
     let mut zip_writer = ZipWriter::new(file);
 
@@ -173,50 +228,80 @@ pub fn create_zip_archive(
         .unix_permissions(0o755);
 
     for entry in WalkDir::new(&path) {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                sentry::capture_message(
+                    &format!("Error walking directory: {}", e),
+                    sentry::Level::Warning,
+                );
+                log::warn!("Error walking directory: {}", e);
+                continue;
+            }
+        };
         let entry_path = entry.path();
-        if entry_path.is_file() {
-            let relative_path = match entry_path.strip_prefix(&path) {
-                Ok(path) => path,
-                Err(e) => {
+        if !entry_path.is_file() {
+            continue;
+        }
+        let relative_path = match entry_path.strip_prefix(&path) {
+            Ok(path) => path,
+            Err(e) => {
+                sentry::capture_message(
+                    &format!("Error stripping prefix: {}", e),
+                    sentry::Level::Warning,
+                );
+                log::warn!("Error stripping prefix: {}", e);
+                continue;
+            }
+        };
+        let zip_name = match zip_path_string(relative_path) {
+            Some(name) => name,
+            None => {
+                log::warn!(
+                    "Skipping file with non-UTF8 path inside zip: {:?}",
+                    relative_path
+                );
+                continue;
+            }
+        };
+        log::info!("zip entry {}", zip_name);
+        if let Err(e) = zip_writer.start_file(&zip_name, options) {
+            sentry::capture_message(
+                &format!("Error starting file in zip ({}): {}", zip_name, e),
+                sentry::Level::Warning,
+            );
+            log::warn!("Error starting file in zip ({}): {}", zip_name, e);
+            continue;
+        }
+        // Stream the file rather than reading it all into memory – savegames
+        // can be hundreds of megabytes and `fs::read` would briefly double the
+        // peak memory usage.
+        match File::open(entry_path) {
+            Ok(mut input) => {
+                if let Err(e) = std::io::copy(&mut input, &mut zip_writer) {
                     sentry::capture_message(
-                        &format!("Error stripping prefix: {}", e.to_string()),
-                        sentry::Level::Error,
+                        &format!("Error writing file to zip ({}): {}", zip_name, e),
+                        sentry::Level::Warning,
                     );
-                    log::error!("Error stripping prefix: {}", e);
-                    continue;
-                }
-            };
-            log::info!("entry {:?}", relative_path);
-            match zip_writer.start_file(relative_path.to_str().unwrap(), options) {
-                Ok(_) => (),
-                Err(e) => {
-                    sentry::capture_message(
-                        &format!("Error starting file in zip: {}", e.to_string()),
-                        sentry::Level::Error,
-                    );
-                    log::error!("Error starting file in zip: {}", e);
+                    log::warn!("Error writing file to zip ({}): {}", zip_name, e);
                     continue;
                 }
             }
-            match zip_writer.write_all(&std::fs::read(entry_path)?) {
-                Ok(_) => (),
-                Err(e) => {
-                    sentry::capture_message(
-                        &format!("Error writing file to zip: {}", e.to_string()),
-                        sentry::Level::Error,
-                    );
-                    log::error!("Error writing file to zip: {}", e);
-                    continue;
-                }
+            Err(e) => {
+                sentry::capture_message(
+                    &format!("Error opening source file for zip ({}): {}", zip_name, e),
+                    sentry::Level::Warning,
+                );
+                log::warn!("Error opening source file for zip ({}): {}", zip_name, e);
+                continue;
             }
         }
     }
 
     zip_writer.finish()?;
-    let pth_str = &output_path.clone().to_string_lossy().into_owned();
+    let pth_str = output_path.to_string_lossy().into_owned();
     log::info!("Created ZIP archive: {:?}", pth_str);
-    Ok(JsonValue::String(pth_str.to_string()))
+    Ok(JsonValue::String(pth_str))
 }
 
 // Takes an xml as string and converts it to json
@@ -242,15 +327,16 @@ pub fn convert_xml_to_json(xml: &str) -> JsonValue {
 pub fn get_folder_content(app: AppHandle, dir: &str) -> JsonValue {
     log::info!("get_folder_content {}", dir);
 
-    let path = match app.path().resolve(dir, BaseDirectory::Document) {
+    let normalized = normalize_relative_path(dir);
+    let path = match app.path().resolve(&normalized, BaseDirectory::Document) {
         Ok(p) => p,
         Err(e) => {
             sentry::capture_message(
-                &format!("Error resolving path: {}", e.to_string()),
+                &format!("Error resolving path '{}': {}", normalized, e),
                 sentry::Level::Error,
             );
 
-            log::error!("Error resolving path: {}", e);
+            log::error!("Error resolving path '{}': {}", normalized, e);
 
             return JsonValue::Null;
         }
@@ -262,6 +348,7 @@ pub fn get_folder_content(app: AppHandle, dir: &str) -> JsonValue {
     }
 
     let mut savegame_folders = Vec::<String>::new();
+    let re = Regex::new(r"^savegame\d").unwrap();
 
     for entry in WalkDir::new(&path)
         .max_depth(1)
@@ -270,16 +357,12 @@ pub fn get_folder_content(app: AppHandle, dir: &str) -> JsonValue {
         .filter(|e| e.file_type().is_dir())
     {
         let entry_path = entry.path();
-        let re = Regex::new(r"^savegame\d").unwrap();
-        if re.is_match(entry_path.file_name().unwrap().to_str().unwrap()) {
-            savegame_folders.push(
-                entry_path
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .to_string(),
-            );
+        let name = match entry_path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if re.is_match(name) {
+            savegame_folders.push(name.to_string());
         }
     }
     log::info!("get_folder_content {}", savegame_folders.len());
@@ -291,28 +374,26 @@ pub fn get_folder_content(app: AppHandle, dir: &str) -> JsonValue {
 #[tauri::command]
 pub async fn read_files_as_zip(app: AppHandle, path: String, filename: String) -> JsonValue {
     log::info!("read_files_as_zip {:?} {:?}", path, filename);
-    let doc_path = match app
-        .path()
-        .resolve(path.to_string(), BaseDirectory::Document)
-    {
+    let normalized = normalize_relative_path(&path);
+    let doc_path = match app.path().resolve(&normalized, BaseDirectory::Document) {
         Ok(p) => p,
         Err(e) => {
             sentry::capture_message(
                 &format!(
-                    "Error reading the files at the specified path: {}",
-                    e.to_string()
+                    "Error reading the files at the specified path '{}': {}",
+                    normalized, e
                 ),
                 sentry::Level::Error,
             );
             log::error!(
                 "Error reading the files at the specified path {}: {}",
-                path,
+                normalized,
                 e
             );
             return JsonValue::Null;
         }
     }
-    .join(filename.to_string());
+    .join(&filename);
 
     if !doc_path.exists() {
         log::error!("DocPath to be read does not exist: {:?}", doc_path);
@@ -338,14 +419,14 @@ pub async fn read_files_as_zip(app: AppHandle, path: String, filename: String) -
     };
 
     match create_zip_archive(doc_path, file_path) {
-        Ok(json_str) => json_str.into(),
+        Ok(json_str) => json_str,
         Err(e) => {
             sentry::capture_message(
                 &format!("Error creating zip archive: {}", e.to_string()),
                 sentry::Level::Error,
             );
             log::error!("Error creating zip archive: {}", e);
-            return JsonValue::Null;
+            JsonValue::Null
         }
     }
 }
@@ -362,10 +443,10 @@ pub fn read_file_in_zip(path_to_zip: PathBuf, filename: &str) -> Option<String> 
         Ok(file) => file,
         Err(e) => {
             sentry::capture_message(
-                &format!("Error opening zip file: {}", e.to_string()),
+                &format!("Error opening zip file {:?}: {}", path_to_zip, e),
                 sentry::Level::Error,
             );
-            log::error!("Error opening zip file: {}", e);
+            log::error!("Error opening zip file {:?}: {}", path_to_zip, e);
             return None;
         }
     };
@@ -373,45 +454,53 @@ pub fn read_file_in_zip(path_to_zip: PathBuf, filename: &str) -> Option<String> 
     let mut archive = match ZipArchive::new(BufReader::new(file)) {
         Ok(archive) => archive,
         Err(e) => {
-            if e.to_string().contains("invalid Zip archive") {
+            let msg = e.to_string();
+            // Common case: a non-mod zip that just isn't a valid archive.
+            // Don't spam Sentry for that.
+            if msg.contains("invalid Zip archive") || msg.contains("Could not find EOCD") {
+                log::warn!("Skipping invalid zip {:?}: {}", path_to_zip, msg);
                 return None;
             }
             sentry::capture_message(
-                &format!("Error reading zip archive: {}", e.to_string()),
+                &format!("Error reading zip archive {:?}: {}", path_to_zip, e),
                 sentry::Level::Error,
             );
-            log::error!("Error reading zip archive: {}", e);
+            log::error!("Error reading zip archive {:?}: {}", path_to_zip, e);
             return None;
         }
     };
+
+    // Compare without depending on a specific path separator. ZIP files are
+    // supposed to use forward slashes per spec, but plenty of writers don't
+    // honour that, especially the Windows-built ones.
+    let target = filename.replace('\\', "/");
 
     for i in 0..archive.len() {
         let mut file = match archive.by_index(i) {
             Ok(file) => file,
             Err(e) => {
                 sentry::capture_message(
-                    &format!("Error accessing file in zip archive: {}", e.to_string()),
-                    sentry::Level::Error,
+                    &format!("Error accessing file in zip archive: {}", e),
+                    sentry::Level::Warning,
                 );
-                log::error!("Error accessing file in zip archive: {}", e);
+                log::warn!("Error accessing file in zip archive: {}", e);
                 continue;
             }
         };
 
-        if let Some(name) = file.enclosed_name() {
-            if name.to_str() == Some(filename) {
-                let mut contents = String::new();
-                if let Err(e) = file.read_to_string(&mut contents) {
-                    sentry::capture_message(
-                        &format!("Error reading file content: {}", e.to_string()),
-                        sentry::Level::Error,
-                    );
-                    log::error!("Error reading file content: {}", e);
-                    return None;
-                }
-                return Some(contents);
+        let normalized_name = file.name().replace('\\', "/");
+        if normalized_name == target {
+            let mut contents = String::new();
+            if let Err(e) = file.read_to_string(&mut contents) {
+                sentry::capture_message(
+                    &format!("Error reading file content from zip {:?}: {}", path_to_zip, e),
+                    sentry::Level::Error,
+                );
+                log::error!("Error reading file content from zip {:?}: {}", path_to_zip, e);
+                return None;
             }
+            return Some(contents);
         }
     }
-    return Some("".to_string());
+    Some(String::new())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,15 +21,22 @@ use tauri::{
 };
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_sentry::{minidump, sentry};
-use winapi::shared::minwindef::DWORD;
 
 static mut PROCESS_EXITED: bool = false;
 static mut PROCESS_RUNNING: bool = false;
 
+#[cfg(target_os = "windows")]
 static PROCESS_NAME: &str = "FarmingSimulator2025Game.exe";
-// Asserts default windows installation path
+#[cfg(not(target_os = "windows"))]
+static PROCESS_NAME: &str = "FarmingSimulator2025";
+
+// Default install location on Windows. Other platforms have no official FS25 build,
+// so we fall back to letting the user pick the executable manually.
+#[cfg(target_os = "windows")]
 static PROCESS_PATH: &str =
     r"C:\Program Files (x86)\Farming Simulator 2025\FarmingSimulator2025.exe";
+#[cfg(not(target_os = "windows"))]
+static PROCESS_PATH: &str = "FarmingSimulator2025";
 
 // Returns the version number from the cargo.toml
 #[tauri::command]
@@ -45,7 +52,7 @@ async fn watch_farming_simulator_25(app: AppHandle) {
     check_process(&app_handle);
 
     loop {
-        if (unsafe { PROCESS_EXITED } == true) {
+        if unsafe { PROCESS_EXITED } == true {
             unsafe {
                 PROCESS_EXITED = false;
             }
@@ -56,6 +63,7 @@ async fn watch_farming_simulator_25(app: AppHandle) {
     }
 }
 
+#[cfg(target_os = "windows")]
 fn get_app_path(app_name: &str) -> Option<String> {
     let output = Command::new("where").arg(app_name).output().ok()?;
 
@@ -63,6 +71,22 @@ fn get_app_path(app_name: &str) -> Option<String> {
         String::from_utf8(output.stdout)
             .ok()
             .map(|path| path.trim().to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn get_app_path(app_name: &str) -> Option<String> {
+    let output = Command::new("which").arg(app_name).output().ok()?;
+
+    if output.status.success() {
+        let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
+        if path.is_empty() {
+            None
+        } else {
+            Some(path)
+        }
     } else {
         None
     }
@@ -76,9 +100,27 @@ async fn start_farming_simulator_25(app: AppHandle) {
         return;
     }
     let app_path = get_app_path(PROCESS_NAME).unwrap_or_else(|| PROCESS_PATH.to_string());
-    Command::new(app_path)
-        .spawn()
-        .expect("Failed to start process");
+
+    let spawn_result = {
+        #[cfg(target_os = "macos")]
+        {
+            // On macOS prefer `open -a` so the user does not need to know the bundle path.
+            Command::new("open").args(["-a", &app_path]).spawn()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Command::new(&app_path).spawn()
+        }
+    };
+
+    if let Err(e) = spawn_result {
+        sentry::capture_message(
+            &format!("Failed to start process at {}: {}", app_path, e),
+            sentry::Level::Error,
+        );
+        log::error!("Failed to start process at {}: {}", app_path, e);
+        return;
+    }
 
     match app.emit("process-started", ()) {
         Ok(_) => {}
@@ -142,9 +184,9 @@ fn check_process(app: &AppHandle) {
     }
 }
 
-fn get_process_id(process_name: &str) -> Option<DWORD> {
+#[cfg(target_os = "windows")]
+fn get_process_id(process_name: &str) -> Option<u32> {
     let mut cmd = Command::new("tasklist");
-    #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW constant
@@ -169,13 +211,40 @@ fn get_process_id(process_name: &str) -> Option<DWORD> {
     for line in lines.iter().skip(1) {
         let process_info: Vec<&str> = line.trim().split_whitespace().collect();
         if process_info.len() >= 2 {
-            if let Ok(pid) = process_info[1].parse::<DWORD>() {
+            if let Ok(pid) = process_info[1].parse::<u32>() {
                 return Some(pid);
             }
         }
     }
 
     None
+}
+
+#[cfg(not(target_os = "windows"))]
+fn get_process_id(process_name: &str) -> Option<u32> {
+    // `pgrep -x` matches the process name exactly. On macOS/Linux the FS25 binary
+    // (when run e.g. through Wine/CrossOver) is generally not detectable via the
+    // exact name, so fall back to a substring search.
+    let exact = Command::new("pgrep").arg("-x").arg(process_name).output();
+    let pid_string = match exact {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        _ => {
+            let fuzzy = Command::new("pgrep")
+                .arg("-f")
+                .arg(process_name)
+                .output()
+                .ok()?;
+            if !fuzzy.status.success() {
+                return None;
+            }
+            String::from_utf8_lossy(&fuzzy.stdout).trim().to_string()
+        }
+    };
+
+    pid_string
+        .lines()
+        .next()
+        .and_then(|line| line.trim().parse::<u32>().ok())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -205,10 +274,11 @@ pub fn run() {
             #[cfg(not(target_os = "linux"))]
             if let tauri::WindowEvent::Moved(position) = event {
                 print!("position {:?}", position);
-                if position.x < -1960 && position.y < -1080 && window.is_visible().unwrap() {
+                if position.x < -1960 && position.y < -1080 && window.is_visible().unwrap_or(false)
+                {
                     std::thread::sleep(Duration::from_millis(100));
 
-                    window.hide().unwrap();
+                    let _ = window.hide();
                 }
             }
         })
@@ -279,7 +349,7 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
         .run(|_app_handle, event| match event {
-            tauri::RunEvent::ExitRequested { api, code, .. } if code.unwrap() == 666 => {
+            tauri::RunEvent::ExitRequested { api, code, .. } if code.unwrap_or(0) == 666 => {
                 api.prevent_exit();
             }
             _ => {}

--- a/src-tauri/src/mods.rs
+++ b/src-tauri/src/mods.rs
@@ -5,52 +5,89 @@ use crate::{
 
 use filetime::FileTime;
 use serde_json::Value as JsonValue;
-use std::{fs, path::Path};
+use std::{fs, path::Path, path::PathBuf};
 use tauri::{path::BaseDirectory, Manager};
 use tauri_plugin_sentry::sentry;
 
-// Returns an array of metadata of all mods
-#[tauri::command]
-pub fn read_mod_desc_files(app_handle: tauri::AppHandle) -> JsonValue {
-    log::info!("read_mod_desc_files");
+/// Returns the mods directory for FS25.
+///
+/// If the frontend supplies a `documents_relative_dir` (the user-configured FS25
+/// game-data directory, relative to the platform's Documents folder), we resolve
+/// against that. Otherwise we fall back to the Windows-default location. On
+/// macOS / Linux the Documents-based default rarely exists, but the resolution
+/// itself is platform-agnostic so we still return a valid path that the caller
+/// can existence-check.
+fn resolve_mods_dir(
+    app_handle: &tauri::AppHandle,
+    documents_relative_dir: Option<&str>,
+) -> Option<PathBuf> {
+    let relative = documents_relative_dir
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            // Normalize backslashes to forward slashes so resolve() works on
+            // platforms that don't treat `\` as a separator.
+            let normalized = s.replace('\\', "/");
+            if normalized.ends_with("/mods") {
+                normalized
+            } else {
+                format!("{}/mods", normalized.trim_end_matches('/'))
+            }
+        })
+        .unwrap_or_else(|| "My Games/FarmingSimulator2025/mods".to_string());
 
-    let binding = match app_handle.path().resolve(
-        "My Games/FarmingSimulator2025/mods",
-        BaseDirectory::Document,
-    ) {
-        Ok(path) => path,
+    match app_handle.path().resolve(&relative, BaseDirectory::Document) {
+        Ok(path) => Some(path),
         Err(e) => {
             sentry::capture_message(
-                &format!("Error creating zip archive: {}", e.to_string()),
+                &format!("Error resolving mods path '{}': {}", relative, e),
                 sentry::Level::Error,
             );
-            log::error!("Error creating zip archive: {}", e);
-            return JsonValue::Null;
-        }
-    };
-
-    let doc_path = binding.as_path();
-
-    if !doc_path.exists() {
-        log::error!("DocPath to be read does not exist: {:?}", doc_path);
-        return JsonValue::Null;
-    }
-
-    match parse_mod_desc_files(doc_path) {
-        Ok(mods) => mods.into(),
-        Err(e) => {
-            sentry::capture_message(
-                &format!("Error building JSON from XML: {}", e.to_string()),
-                sentry::Level::Error,
-            );
-            log::error!("Error building JSON from XML: {}", e);
-            return JsonValue::Null;
+            log::error!("Error resolving mods path '{}': {}", relative, e);
+            None
         }
     }
 }
 
-// Parses all mod description files.
-pub fn parse_mod_desc_files(folder: &Path) -> Result<JsonValue, JsonValue> {
+// Returns an array of metadata of all mods.
+//
+// `documents_relative_dir` is optional and, when provided, points at the FS25
+// game-data directory relative to Documents. The function always appends `/mods`.
+#[tauri::command]
+pub fn read_mod_desc_files(
+    app_handle: tauri::AppHandle,
+    documents_relative_dir: Option<String>,
+) -> JsonValue {
+    log::info!(
+        "read_mod_desc_files (relative dir: {:?})",
+        documents_relative_dir
+    );
+
+    let doc_path = match resolve_mods_dir(&app_handle, documents_relative_dir.as_deref()) {
+        Some(path) => path,
+        None => return JsonValue::Null,
+    };
+
+    if !doc_path.exists() {
+        log::error!("Mods path does not exist: {:?}", doc_path);
+        return JsonValue::Null;
+    }
+
+    match parse_mod_desc_files(doc_path.as_path()) {
+        Ok(mods) => mods,
+        Err(e) => {
+            sentry::capture_message(
+                &format!("Error parsing mod descriptions: {}", e),
+                sentry::Level::Error,
+            );
+            log::error!("Error parsing mod descriptions: {}", e);
+            JsonValue::Null
+        }
+    }
+}
+
+// Parses all mod description files. Errors on individual mods are logged and
+// the mod is skipped, instead of aborting the whole scan.
+pub fn parse_mod_desc_files(folder: &Path) -> Result<JsonValue, String> {
     log::info!("parse_mod_desc_files {:?}", folder);
 
     let cached_response_file = folder.join("mods.json");
@@ -58,55 +95,80 @@ pub fn parse_mod_desc_files(folder: &Path) -> Result<JsonValue, JsonValue> {
     let mut cached_mod_desc: CachedModDescriptions = CachedModDescriptions { mods: vec![] };
 
     if cached_response_file.exists() {
-        let file_content = match std::fs::read_to_string(&cached_response_file) {
-            Ok(content) => content,
+        match std::fs::read_to_string(&cached_response_file) {
+            Ok(content) => match serde_json::from_str::<CachedModDescriptions>(&content) {
+                Ok(json) => cached_mod_desc = json,
+                Err(e) => {
+                    // Don't fail the whole scan – just discard the cache.
+                    sentry::capture_message(
+                        &format!("Error parsing cached mod descriptions, ignoring cache: {}", e),
+                        sentry::Level::Warning,
+                    );
+                    log::warn!("Error parsing cached mod descriptions, ignoring cache: {}", e);
+                }
+            },
             Err(e) => {
                 sentry::capture_message(
-                    &format!("Error reading cached response file: {}", e.to_string()),
-                    sentry::Level::Error,
+                    &format!("Error reading cached mod descriptions, ignoring cache: {}", e),
+                    sentry::Level::Warning,
                 );
-                log::error!("Error reading cached response file: {}", e);
-                return Err(JsonValue::Null);
+                log::warn!("Error reading cached mod descriptions, ignoring cache: {}", e);
             }
-        };
-
-        // Parse the file as Array of ModDesc structs
-        let json: CachedModDescriptions = match serde_json::from_str(&file_content) {
-            Ok(json) => json,
-            Err(e) => {
-                sentry::capture_message(
-                    &format!("Error parsing cached response file: {}", e.to_string()),
-                    sentry::Level::Error,
-                );
-                log::error!("Error parsing cached response file: {}", e);
-                return Err(JsonValue::Null);
-            }
-        };
-
-        cached_mod_desc = json;
+        }
     }
 
     let files = get_zip_file_paths(folder);
 
-    println!("Found {} files", files.len());
-    println!("Cached mods: {}", cached_mod_desc.mods.len());
+    log::info!("Found {} mod files, {} cached", files.len(), cached_mod_desc.mods.len());
 
     let mut mods: Vec<JsonValue> = vec![];
-    for entry in files {
-        // // Find entry of cached_mod_desc where filename matches entry
-        let cached_mod = cached_mod_desc
-            .mods
-            .iter()
-            .find(|m| m.filename == entry.file_name().unwrap().to_str().unwrap().to_string());
+    let mut updated_cache: Vec<CachedModDesc> = vec![];
 
-        let metadata = fs::metadata(&entry).unwrap();
+    for entry in files {
+        let filename_os = match entry.file_name() {
+            Some(name) => name,
+            None => continue,
+        };
+        let filename = match filename_os.to_str() {
+            Some(s) => s.to_string(),
+            None => {
+                log::warn!("Skipping mod with non-UTF8 filename: {:?}", entry);
+                continue;
+            }
+        };
+
+        if !filename.starts_with("FS25_") {
+            continue;
+        }
+
+        // Find entry in cache where filename matches.
+        let cached_mod = cached_mod_desc.mods.iter().find(|m| m.filename == filename);
+
+        let metadata = match fs::metadata(&entry) {
+            Ok(m) => m,
+            Err(e) => {
+                sentry::capture_message(
+                    &format!("Error reading metadata for mod {}: {}", filename, e),
+                    sentry::Level::Warning,
+                );
+                log::warn!("Error reading metadata for mod {}: {}", filename, e);
+                continue;
+            }
+        };
         let mtime = FileTime::from_last_modification_time(&metadata);
 
-        // if cached_mod is found and the modification time is the same, use the cached_mod
+        // If cached_mod is found and the modification time matches, reuse the cache.
         if let Some(cached_mod) = cached_mod {
             if cached_mod.modified_at == mtime.nanoseconds() {
-                mods.push(serde_json::to_value(cached_mod.mods.clone()).unwrap());
-                println!("Using cached mod: {}", cached_mod.filename);
+                if let Ok(json) = serde_json::to_value(cached_mod.mods.clone()) {
+                    mods.push(json);
+                }
+                updated_cache.push(CachedModDesc {
+                    filename: cached_mod.filename.clone(),
+                    modified_at: cached_mod.modified_at,
+                    mods: cached_mod.mods.clone(),
+                });
+                log::info!("Using cached mod: {}", cached_mod.filename);
                 continue;
             }
         }
@@ -116,116 +178,129 @@ pub fn parse_mod_desc_files(folder: &Path) -> Result<JsonValue, JsonValue> {
             None => continue,
         };
 
-        if file_content.len() == 0 {
+        if file_content.is_empty() {
             continue;
         }
 
-        let file_content = file_content.replace("&", "&amp;");
-        let json = &convert_xml_to_json(&file_content);
-
-        let filename = match entry.file_name() {
-            Some(name) => name.to_string_lossy().to_string(),
-            None => continue,
-        };
-
-        if !filename.starts_with("FS25_") {
-            continue;
-        }
-
-        let copied_filename = filename.clone();
+        // Escape stray ampersands without double-escaping already-encoded entities.
+        let safe_xml = escape_unescaped_ampersands(&file_content);
+        let json = convert_xml_to_json(&safe_xml);
 
         let titles = match json.get("modDesc").and_then(|md| md.get("title")) {
             Some(title) => title.clone(),
             None => {
-                sentry::capture_message("Error: title not found in modDesc", sentry::Level::Error);
-                log::error!("Error: title not found in modDesc");
-                return Err(JsonValue::Null);
+                log::warn!("Skipping mod {}: title not found in modDesc", filename);
+                continue;
             }
         };
         let description = match json.get("modDesc").and_then(|md| md.get("description")) {
             Some(description) => description.clone(),
             None => {
-                sentry::capture_message(
-                    "Error: description not found in modDesc",
-                    sentry::Level::Error,
-                );
-                log::error!("Error: description not found in modDesc");
-                return Err(JsonValue::Null);
+                log::warn!("Skipping mod {}: description not found in modDesc", filename);
+                continue;
+            }
+        };
+
+        let version = match json.get("modDesc").and_then(|md| md.get("version")) {
+            Some(version) => match version.as_array().and_then(|arr| arr.get(0)) {
+                Some(v) => v.to_string().replace('"', ""),
+                None => {
+                    log::warn!("Skipping mod {}: version is not a non-empty array", filename);
+                    continue;
+                }
+            },
+            None => {
+                log::warn!("Skipping mod {}: version not found in modDesc", filename);
+                continue;
             }
         };
 
         let simplified_mod = SimplifiedModDesc {
-            mod_name: filename.replace(".zip", ""),
-            filename,
+            mod_name: filename.trim_end_matches(".zip").to_string(),
+            filename: filename.clone(),
             titles,
             description,
-            version: match json.get("modDesc").and_then(|md| md.get("version")) {
-                Some(version) => match version.as_array() {
-                    Some(array) => array[0].to_string().replace('"', ""),
-                    None => {
-                        sentry::capture_message(
-                            "Error: version is not an array",
-                            sentry::Level::Error,
-                        );
-                        log::error!("Error: version is not an array");
-                        return Err(JsonValue::Null);
-                    }
-                },
-                None => {
-                    sentry::capture_message(
-                        "Error: version not found in modDesc",
-                        sentry::Level::Error,
-                    );
-                    log::error!("Error: version not found in modDesc");
-                    return Err(JsonValue::Null);
-                }
-            },
+            version,
         };
 
-        // create a cachedModDesc from mod
-        let cached_mod = CachedModDesc {
-            filename: copied_filename,
+        updated_cache.push(CachedModDesc {
+            filename: filename.clone(),
             modified_at: mtime.nanoseconds(),
             mods: simplified_mod.clone(),
-        };
-        // add cached_mod to cached_mod_desc
-        cached_mod_desc.mods.push(cached_mod);
+        });
 
         match serde_json::to_value(simplified_mod) {
-            Ok(mod_json) => {
-                mods.push(mod_json);
-            }
+            Ok(mod_json) => mods.push(mod_json),
             Err(e) => {
                 sentry::capture_message(
-                    &format!("Error serializing mod: {}", e.to_string()),
-                    sentry::Level::Error,
+                    &format!("Error serializing mod {}: {}", filename, e),
+                    sentry::Level::Warning,
                 );
-                sentry::capture_message(
-                    &format!("Error serializing mod: {}", e.to_string()),
-                    sentry::Level::Error,
-                );
-                log::error!("Error serializing mod: {}", e);
-                return Err(JsonValue::Null);
+                log::warn!("Error serializing mod {}: {}", filename, e);
             }
         }
     }
 
-    // Write the mods to the cache file
-    let json = serde_json::to_string(&CachedModDescriptions {
-        mods: cached_mod_desc.mods,
-    })
-    .unwrap();
-    match std::fs::write(cached_response_file, json) {
-        Ok(_) => {}
+    // Write the updated mods cache. A failure here should not abort the result.
+    match serde_json::to_string(&CachedModDescriptions {
+        mods: updated_cache,
+    }) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(&cached_response_file, json) {
+                sentry::capture_message(
+                    &format!("Error writing cached response file: {}", e),
+                    sentry::Level::Warning,
+                );
+                log::warn!("Error writing cached response file: {}", e);
+            }
+        }
         Err(e) => {
             sentry::capture_message(
-                &format!("Error writing cached response file: {}", e.to_string()),
-                sentry::Level::Error,
+                &format!("Error serializing cached mods: {}", e),
+                sentry::Level::Warning,
             );
-            log::error!("Error writing cached response file: {}", e);
-            return Err(JsonValue::Null);
+            log::warn!("Error serializing cached mods: {}", e);
         }
     }
 
-    return Ok(JsonValue::Array(mods));
+    Ok(JsonValue::Array(mods))
+}
+
+/// Escapes bare `&` characters without disturbing already-escaped entities like
+/// `&amp;`, `&lt;`, `&#x20;`, etc. Many modDesc.xml files in the wild contain
+/// raw `&` in titles or descriptions, which the XML parser would otherwise
+/// reject; the previous naive `replace("&", "&amp;")` corrupted valid entities.
+fn escape_unescaped_ampersands(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if c == '&' {
+            // Look ahead for a valid entity terminated by `;` within a small window.
+            let mut j = i + 1;
+            let max = (i + 12).min(bytes.len());
+            let mut found_semi = false;
+            while j < max {
+                let b = bytes[j];
+                if b == b';' {
+                    found_semi = true;
+                    break;
+                }
+                if !(b.is_ascii_alphanumeric() || b == b'#') {
+                    break;
+                }
+                j += 1;
+            }
+            if found_semi {
+                out.push('&');
+            } else {
+                out.push_str("&amp;");
+            }
+        } else {
+            out.push(c);
+        }
+        i += 1;
+    }
+    out
 }

--- a/src-tauri/src/savegame.rs
+++ b/src-tauri/src/savegame.rs
@@ -9,32 +9,52 @@ use zip::ZipArchive;
 use crate::farms_structs::Farms;
 use crate::savegame_structs::CareerSavegame;
 
+/// Normalises a documents-relative path to forward slashes so the resolver and
+/// the OS file APIs both accept it on every platform.
+fn normalize_relative(input: &str) -> String {
+    input.replace('\\', "/")
+}
+
 // Saves a savegame (in zip format from server) to the given directory.
 #[tauri::command]
 pub fn unwrap_and_save_savegame(app: AppHandle, data: Vec<u8>, dir: &str) -> JsonValue {
     log::info!("unwrap_and_save_savegame {:?}", dir);
 
-    let dir_path: std::path::PathBuf = match app.path().resolve(dir, BaseDirectory::Document) {
+    let normalized = normalize_relative(dir);
+    let dir_path: std::path::PathBuf = match app.path().resolve(&normalized, BaseDirectory::Document) {
         Ok(p) => p,
         Err(e) => {
             sentry::capture_message(
-                &format!("Error creating zip archive: {}", e.to_string()),
+                &format!("Error resolving savegame target dir '{}': {}", normalized, e),
                 sentry::Level::Error,
             );
-            log::error!("Error creating zip archive: {}", e);
+            log::error!("Error resolving savegame target dir '{}': {}", normalized, e);
             return JsonValue::Null;
         }
     };
 
+    if let Some(parent) = dir_path.parent() {
+        if !parent.exists() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                sentry::capture_message(
+                    &format!("Error creating savegame parent dir {:?}: {}", parent, e),
+                    sentry::Level::Error,
+                );
+                log::error!("Error creating savegame parent dir {:?}: {}", parent, e);
+                return JsonValue::Null;
+            }
+        }
+    }
+
     match unwrap_savegame(data, dir_path.as_path()) {
-        Ok(bool) => bool.into(),
+        Ok(value) => value,
         Err(e) => {
             sentry::capture_message(
-                &format!("Error creating zip archive: {}", e.to_string()),
+                &format!("Error unwrapping savegame: {}", e),
                 sentry::Level::Error,
             );
-            log::error!("Error creating zip archive: {}", e);
-            return JsonValue::Null;
+            log::error!("Error unwrapping savegame: {}", e);
+            JsonValue::Null
         }
     }
 }
@@ -43,27 +63,29 @@ pub fn unwrap_and_save_savegame(app: AppHandle, data: Vec<u8>, dir: &str) -> Jso
 pub fn parse_local_savegame_data(app: AppHandle, savegame_path: &str) -> JsonValue {
     log::info!("parse_local_savegame_data {:?}", savegame_path);
 
-    let savegame_path = match app.path().resolve(savegame_path, BaseDirectory::Document) {
-        Ok(bool) => bool,
+    let normalized = normalize_relative(savegame_path);
+    let savegame_path = match app.path().resolve(&normalized, BaseDirectory::Document) {
+        Ok(p) => p,
         Err(e) => {
             sentry::capture_message(
-                &format!("Error creating savegame path: {}", e.to_string()),
+                &format!("Error creating savegame path '{}': {}", normalized, e),
                 sentry::Level::Error,
             );
-            log::error!("Error creating savegame path: {}", e);
+            log::error!("Error creating savegame path '{}': {}", normalized, e);
             return JsonValue::Null;
         }
     };
 
     if !savegame_path.exists() {
-        log::error!("savegame_path does not exist: {:?}", savegame_path);
+        // Steam-side empty folders are common, so this isn't an error.
+        log::info!("savegame_path does not exist: {:?}", savegame_path);
         return JsonValue::Null;
     }
 
     let career_path = savegame_path.join("careerSavegame.xml");
 
     if !career_path.exists() {
-        log::error!("career_path does not exist: {:?}", career_path);
+        log::info!("career_path does not exist: {:?}", career_path);
         return JsonValue::Null;
     }
 
@@ -71,64 +93,56 @@ pub fn parse_local_savegame_data(app: AppHandle, savegame_path: &str) -> JsonVal
         Ok(file) => file,
         Err(e) => {
             sentry::capture_message(
-                &format!("Error opening career file: {}", e.to_string()),
+                &format!("Error opening career file {:?}: {}", career_path, e),
                 sentry::Level::Error,
             );
-            log::error!("Error opening career file: {}", e);
+            log::error!("Error opening career file {:?}: {}", career_path, e);
             return JsonValue::Null;
         }
     };
     log::info!("career_file");
-    let career_data: CareerSavegame = match serde_xml_rs::from_reader(career_file) {
+    let mut career_data: CareerSavegame = match serde_xml_rs::from_reader(career_file) {
         Ok(data) => data,
         Err(e) => {
             sentry::capture_message(
-                &format!("Error parsing career file: {}", e.to_string()),
+                &format!("Error parsing career file {:?}: {}", career_path, e),
                 sentry::Level::Error,
             );
-            log::error!("Error parsing career file: {}", e);
+            log::error!("Error parsing career file {:?}: {}", career_path, e);
             return JsonValue::Null;
         }
     };
 
+    // farms.xml is optional – missing it should not invalidate the whole
+    // savegame entry, otherwise the user sees the savegame disappear from the
+    // UI even though it loads fine in the game.
     let farms_path = savegame_path.join("farms.xml");
-
-    if !farms_path.exists() {
-        log::error!("farms_path does not exist: {:?}", farms_path);
-        return JsonValue::Null;
+    if farms_path.exists() {
+        match File::open(&farms_path) {
+            Ok(farms_file) => match serde_xml_rs::from_reader::<_, Farms>(farms_file) {
+                Ok(data) => career_data.farms = Some(data),
+                Err(e) => {
+                    sentry::capture_message(
+                        &format!("Error parsing farms file {:?}: {}", farms_path, e),
+                        sentry::Level::Warning,
+                    );
+                    log::warn!("Error parsing farms file {:?}: {}", farms_path, e);
+                }
+            },
+            Err(e) => {
+                sentry::capture_message(
+                    &format!("Error opening farms file {:?}: {}", farms_path, e),
+                    sentry::Level::Warning,
+                );
+                log::warn!("Error opening farms file {:?}: {}", farms_path, e);
+            }
+        }
+    } else {
+        log::info!("farms_path does not exist (optional): {:?}", farms_path);
     }
 
-    let farms_file = match File::open(&farms_path) {
-        Ok(file) => file,
-        Err(e) => {
-            sentry::capture_message(
-                &format!("Error opening farms file: {}", e.to_string()),
-                sentry::Level::Error,
-            );
-            log::error!("Error opening farms file: {}", e);
-            return JsonValue::Null;
-        }
-    };
-
-    log::info!("farms_file");
-    let farms_data: Farms = match serde_xml_rs::from_reader(farms_file) {
-        Ok(data) => data,
-        Err(e) => {
-            sentry::capture_message(
-                &format!("Error parsing farms file: {}", e.to_string()),
-                sentry::Level::Error,
-            );
-            log::error!("Error parsing farms file: {}", e);
-            return JsonValue::Null;
-        }
-    };
-
-    // Join career_data with farms_data by adding a farms field to career_data
-    let mut career_data = career_data;
-    career_data.farms = Some(farms_data);
-
     log::info!("done_parsing_local_savegame_data");
-    return career_data.into();
+    career_data.into()
 }
 
 // Unwraps a savegame to dest_path
@@ -138,13 +152,27 @@ pub fn unwrap_savegame(zip_bytes: Vec<u8>, dest_path: &Path) -> Result<JsonValue
     let reader = Cursor::new(zip_bytes);
     let mut archive = ZipArchive::new(reader)?;
 
+    if !dest_path.exists() {
+        std::fs::create_dir_all(dest_path)?;
+    }
+
     for i in 0..archive.len() {
         let mut file = archive.by_index(i)?;
+
+        // `enclosed_name()` rejects paths that try to escape the destination
+        // directory (zip slip). Plus zips written on Windows often use
+        // backslashes which `enclosed_name` already normalises – good.
         let outpath = match file.enclosed_name() {
             Some(path) => dest_path.join(path),
-            None => continue,
+            None => {
+                log::warn!(
+                    "Skipping zip entry with unsafe or non-UTF8 path: {}",
+                    file.name()
+                );
+                continue;
+            }
         };
-        if file.name().ends_with('/') {
+        if file.name().ends_with('/') || file.name().ends_with('\\') {
             std::fs::create_dir_all(&outpath)?;
         } else {
             if let Some(parent) = outpath.parent() {

--- a/src/lib/sync/mods.sync.ts
+++ b/src/lib/sync/mods.sync.ts
@@ -48,8 +48,15 @@ export const getDescriptionFromMod = (mod: Mod) => {
  * @returns an array of local mods. Each mod is an object with properties such as `mod_name`, `description`, and `author`.
  */
 export async function getLocalMods() {
-  const data = ((await invoke("read_mod_desc_files")) as Array<Mod>);
-  const modFiles: Array<Mod> = data?.sort((a, b) => a.modName.localeCompare(b.modName));
+  // Pass the configured game-data directory so the backend respects user-chosen
+  // paths instead of always defaulting to `My Games/FarmingSimulator2025/mods`,
+  // which doesn't exist on macOS / Linux and may be wrong on Windows when the
+  // user picked a custom location.
+  const documentsRelativeDir = await getFS25Dir();
+  const data = ((await invoke("read_mod_desc_files", {
+    documentsRelativeDir: documentsRelativeDir ?? null,
+  })) as Array<Mod> | null) ?? [];
+  const modFiles: Array<Mod> = data.sort((a, b) => a.modName.localeCompare(b.modName));
   const modMap = new Map<string, Mod>();
   for (const modFile of modFiles) {
     modMap.set(modFile.modName + modFile.version, modFile);

--- a/src/lib/sync/shared.sync.ts
+++ b/src/lib/sync/shared.sync.ts
@@ -3,6 +3,7 @@ import { open, confirm } from "@tauri-apps/plugin-dialog";
 import { get } from 'svelte/store';
 import { documentsDefaultDir } from './utils';
 import { config } from '../stores/config.store';
+import { error } from '@tauri-apps/plugin-log';
 
 /**
  * Creates a teamId header for all backend requests to identify the team
@@ -29,12 +30,33 @@ export const getTeamHeader = () => {
  * @param prompt if the user should be prompted if the defaultDir does not exist
  */
 export async function getFS25Dir(prompt = false) {
+  // Prefer a previously-saved game directory from the config – this also covers
+  // macOS / Linux users who don't have a Windows-style "My Games" folder under
+  // Documents and previously had to re-pick the directory every launch.
+  const savedDir = get(config).gameDataDirectory;
+  if (savedDir && savedDir.length > 0 && savedDir !== documentsDefaultDir) {
+    try {
+      const savedExists = await exists(savedDir);
+      if (savedExists) {
+        return savedDir;
+      }
+    } catch (e) {
+      // exists() may throw on absolute paths that the fs scope doesn't grant
+      // access to; fall through to the default behaviour in that case.
+      error(`getFS25Dir saved-dir check failed: ${e}`);
+    }
+  }
+
   try {
     const dirExists = await exists(documentsDefaultDir, {
       baseDir: BaseDirectory.Document,
     });
 
-    if (!dirExists && prompt) {
+    if (dirExists) {
+      return documentsDefaultDir;
+    }
+
+    if (prompt) {
       const confirmation = await confirm(
         "We couldn't find a data-directory for your Farming Simulator 25 game. Please specify.",
         { title: 'No FS25 directory found', kind: 'warning' }
@@ -42,11 +64,15 @@ export async function getFS25Dir(prompt = false) {
       if (!confirmation) {
         return "";
       }
-      return await openDir()
+      return await openDir();
     }
     return documentsDefaultDir;
   } catch (e) {
-    return await openDir();
+    error(`getFS25Dir default-dir check failed: ${e}`);
+    if (prompt) {
+      return await openDir();
+    }
+    return documentsDefaultDir;
   }
 }
 
@@ -61,11 +87,13 @@ export async function openDir() {
   if (directory == null) {
     return;
   }
-  const modsExist = await exists(`${directory}/mods`);
-
-  if (modsExist) {
-    return directory;
-  } else {
-    return null;
+  try {
+    const modsExist = await exists(`${directory}/mods`);
+    if (modsExist) {
+      return directory;
+    }
+  } catch (e) {
+    error(`openDir mods-check failed: ${e}`);
   }
+  return null;
 }

--- a/src/lib/sync/utils.ts
+++ b/src/lib/sync/utils.ts
@@ -11,7 +11,10 @@ import { dev } from '$app/environment';
 export const baseDomain = dev ? "127.0.0.1:8787" : "farm-station-25.eweren.workers.dev";
 export const protocol = dev ? "http" : "https";
 
-export const documentsDefaultDir = "My Games\\FarmingSimulator2025";
+// Forward-slashes work on Windows too (the OS canonicalises), and are required
+// on macOS / Linux where `\` is a regular filename character. The Rust side
+// also normalises any leftover backslashes via `normalize_relative_path`.
+export const documentsDefaultDir = "My Games/FarmingSimulator2025";
 
 /**
  * Fetches the potentially other players that are playing from server.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,6 +32,17 @@
   import LanguageSwitch from "../lib/ui/languageSwitch.svelte";
   import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
   import { cn } from "../lib/utils";
+  import { appLogDir } from "@tauri-apps/api/path";
+
+  // Resolve the actual log directory through Tauri so the path we copy to the
+  // user's clipboard is correct on Windows (%LocalAppData%/...), macOS
+  // (~/Library/Logs/...), and Linux (~/.local/share/.../logs).
+  let logsPath = "";
+  appLogDir()
+    .then((p) => (logsPath = p))
+    .catch(() => {
+      logsPath = "%LocalAppData%\\de.farm-station-25.app\\logs";
+    });
 
   let loading = true;
 
@@ -48,7 +59,7 @@
           label: $t("copy_path"),
           onClick: () => {
             navigator.clipboard
-              .writeText("%LocalAppData%\\de.farm-station-25.app\\logs")
+              .writeText(logsPath)
               .then(() => {
                 toast.success($t("copied"), {
                   duration: 2000,


### PR DESCRIPTION
The app bundles for Windows, macOS and Linux but several layers were
hard-coded to Windows, which produced the recurring Sentry events about
files that "could not be parsed/found/read" – and on non-Windows builds
the Rust crate didn't even compile.

Rust backend
- Drop the unconditional `winapi` import from `lib.rs`; gate process
  detection/start with `#[cfg(target_os = "windows")]` and add macOS /
  Linux equivalents (`pgrep`, `which`, `open -a`).
- `mods.rs::read_mod_desc_files` now accepts the configured FS25 game
  directory from the frontend instead of hard-coding
  `My Games/FarmingSimulator2025/mods`.
- Replace `unwrap()` panics in mod scanning with graceful skips so a
  single bad mod no longer aborts the whole scan or crashes the process.
- New `escape_unescaped_ampersands` keeps existing XML entities intact
  (the previous `replace("&", "&amp;")` corrupted any `&amp;`/`&lt;`).
- `file_utils.rs` always emits forward-slash paths into ZIP archives
  (the spec mandates them) and normalises backslashes when reading
  entries back, so archives created on Windows can still be opened on
  macOS / Linux.
- Add `normalize_relative_path` helpers in `file_utils.rs` /
  `savegame.rs` so any backslashes coming from older configs work
  everywhere.
- Stream files into the savegame ZIP instead of buffering each entry
  in memory.
- `parse_local_savegame_data` now keeps the career data when
  `farms.xml` is missing/corrupt instead of dropping the whole entry.
- `unwrap_and_save_savegame` and `save_config` create their target
  directories first.

Frontend
- `documentsDefaultDir` is now `"My Games/FarmingSimulator2025"`. On
  macOS / Linux backslashes are regular filename chars, which made the
  resolver build a literal `My Games\FarmingSimulator2025` directory.
- `getFS25Dir` first checks the saved `gameDataDirectory` from the
  config so users on platforms without the Windows default don't get
  prompted on every launch.
- `getLocalMods` forwards the resolved directory to the Rust mod
  scanner.
- The "copy logs path" toast now uses Tauri's `appLogDir()` so the
  copied path is correct on every OS instead of always pointing at
  `%LocalAppData%`.